### PR TITLE
#33 휴면계정 활성화에 대한 쿼리 오류 검사

### DIFF
--- a/umin_active2.php
+++ b/umin_active2.php
@@ -15,10 +15,20 @@
 
 	$sql = "select * from user where id = '{$id}' and pass = sha2('{$password}' , 0)";
 	$result = mysqli_query($conn, $sql);
+
+	if(!$result)
+	{
+		echo "<script>
+				alert('데이터를 가져오는데 실패했습니다.');
+				location.href='javascript:history.back()';
+				</script>";
+		exit;
+	}
+	
 	$row = mysqli_num_rows($result);
 	$arr = mysqli_fetch_assoc($result);
-
-  mysqli_free_result($result);
+	mysqli_free_result($result);
+	
 	if($password == '')
 	{
 		echo "<script>
@@ -32,19 +42,26 @@
 	if($row>0)
 	{
 		$_SESSION['id'] = $arr['id'];
-
-
-
 		$login_time = date('Y-m-d H:i:s' , time());
 		$sql_login = "update user set last_login = '{$login_time}' , active = 1 where id = '{$id}'";
 		$result_login = mysqli_query($conn, $sql_login);
-
-		echo "<script>
+		
+		if(!$result_login)
+		{
+			echo "<script>
+					alert('계정활성화 과정에서 데이터와 연동하는 작업에 문제가 있습니다.\\n 관리자에게 문의하세요.');
+					location.href='javascript:history.back()';
+				</script>";
+			exit;
+		}
+		else
+		{
+			echo "<script>
 				alert('계정이 활성화 되었습니다');
 				location.href='/board/team-/free_menu.php?page=1';
 				</script>";
-
-			  mysqli_close($conn);
+		}
+			mysqli_close($conn);
 		exit;
 	}
 	else


### PR DESCRIPTION
#33 휴면계정 활성화 시에 전달되어 처리하는 쿼리 구문에 오류가 발생할 경우 오류 구문이 아닌 메세지가 출력되도록 수정함.

DB에서 데이터를 가져오는데 실패할 경우와 계정활성화에 필요한 데이터를 수정하는 경우의 두 가지 경우에 대한 메세지가 각각 출력되도록 수정함.
검토 후 적용 바람.